### PR TITLE
feat: horizonmode display

### DIFF
--- a/common/gcdisplay-rag.lua
+++ b/common/gcdisplay-rag.lua
@@ -125,7 +125,7 @@ function gcdisplay.Load()
             display = display .. '   ' .. key .. ': ' .. '|cFF5FFF5F|' .. value.Array[value.Index] .. '|r'
         end
         display = display .. '   ' .. 'IdleSet' .. ': ' .. '|cFF5FFF5F|' .. gcdisplay.IdleSet .. '|r' .. ' '
-	display = display .. '   ' .. 'HorizonMode' .. ': ' .. '|cFF5FFF5F|' .. tostring(gcinclude.horizon_safe_mode) .. '|r' .. ' '
+        display = display .. '   ' .. 'HorizonMode' .. ': ' .. '|cFF5FFF5F|' .. tostring(gcinclude.horizon_safe_mode) .. '|r' .. ' '
         gcdisplay.FontObject.text = display
     end)
 end


### PR DESCRIPTION
Adds horizonmode to the display. This was comforting to me playing on horizon as the consequences can be severe for not having this enabled.