### PR TITLE
ConserveMP should not be equipped when Singing

### DIFF
--- a/common/gcmage.lua
+++ b/common/gcmage.lua
@@ -729,7 +729,7 @@ function gcmage.DoMidcast(sets, ninSJMMP, whmSJMMP, blmSJMMP, rdmSJMMP, drkSJMMP
 
     if (isNoModSpell) then
         gFunc.EquipSet('Haste')
-        if (action.Skill ~= 'Ninjutsu') then
+        if (action.Skill ~= 'Ninjutsu' and action.Skill ~= 'Singing') then
             gFunc.EquipSet('ConserveMP')
             if (environment.DayElement == 'Water') and (player.MPP <= 85) then
                 if (maxMP == 0 or player.MP < maxMP * 0.85) then
@@ -770,7 +770,7 @@ function gcmage.ShouldSkipCast(maxMP, isNoModSpell)
         end
     end
 
-    if (action.Skill ~= 'Ninjutsu' and player.MPP <= 95) then
+    if (action.Skill ~= 'Ninjutsu' and action.Skill ~= 'Singing' and player.MPP <= 95) then
         gFunc.EquipSet('ConserveMP')
     end
 


### PR DESCRIPTION
Previously there were two places in gcmage where ConserveMP set is considered for equipping; in both cases we check first to make sure the spell being cast is not Ninjutsu. I added an additional check to make sure the spell is not Singing as well (I don't think any songs have mana costs, but I'm not positive).

I discovered this issue because my Dream Sand (Ammo) kept getting equipped during song casts which was unequipping my instrument (Range), leaving me only able to keep one song up at a time.