### PR TITLE
feat: add /gcdisplay toggle

### DIFF
--- a/common/gcdisplay-rag.lua
+++ b/common/gcdisplay-rag.lua
@@ -98,6 +98,7 @@ function gcdisplay.Unload()
         gcdisplay.FontObject = nil
     end
     ashita.events.unregister('d3d_present', 'gcdisplay_present_cb')
+    ashita.events.unregister('command', 'gcdisplay_command_cb')
 end
 
 function gcdisplay.Load()
@@ -128,5 +129,18 @@ function gcdisplay.Load()
         gcdisplay.FontObject.text = display
     end)
 end
+
+ashita.events.register('command', 'gcdisplay_command_cb', function (e)
+    local args = e.command:args()
+    if #args == 0 or args[1] ~= '/gcdisplay' then
+        return
+    end
+
+    e.blocked = true
+
+    if #args == 1 and gcdisplay.FontObject ~= nil then
+        gcdisplay.FontObject.visible = not gcdisplay.FontObject.visible
+    end
+end)
 
 return gcdisplay


### PR DESCRIPTION
Closes #55 

# Fix
Restore functionality from upstream origin for GCdisplay: https://github.com/GetAwayCoxn/Luashitacast-Profiles/blob/main/config/addons/luashitacast/common/gcdisplay.lua#L134-L145

/gcdisplay now toggles the display on and off. However, this will still reinsert itself in the same place on job change. 


------------------------------------------
First approach below: now pursuing the above stated fix:  <details>`/gcdisplay` was a no-op. The command handler was dropped when this overlay was ported from GetAwayCoxn,and `gcdisplay` was never registered in the command system. On top of that, `RetryLoad()` rebuilds the `FontObject` (visible = true) on every job change, and shift dragging the bar away snaps back after a job swap.

**Change** (contained to `gcinclude-rag.lua`; `gcdisplay-rag.lua` untouched):
- New `display_status_bar` setting in the config block to set the default.
- `/gcdisplay` registered in `Commands`; supports `on` / `off` / `toggle` (`show`/`hide` aliases).
- Visibility re-asserted after `gcdisplay.Load()` so it persists across job/zone changes.

Kept the toggle in the config file rather than the overlay file to match the repo's settings-above-banner convention — non-engineers configure the default where they configure everything else.

**Tested:** toggle + explicit on/off; toggle persists across zone. Explicit across zone & job; verified on a melee and a mage job (both fall-through paths); chat message reads correctly.<summary></summary>
</details> 

