### PR TITLE
fix: add commas to fix parsing error

### DIFF
--- a/Rag_5040/NIN.lua
+++ b/Rag_5040/NIN.lua
@@ -555,7 +555,7 @@ local sets = {
     Weapon_Loadout_2 = {
         Main = 'Senjuinrikio',
         Sub = 'Unji',
-        Range = 'displaced'
+        Range = 'displaced',
         Ammo = 'Bomb Core',
     },
     Weapon_Loadout_3 = {},
@@ -583,7 +583,7 @@ local sets = {
     WS_Metsu = {
         Ring1 = 'Thunder Ring',
         Ring2 = 'Adroit Ring',
-    }
+    },
 
     ShinobiRingHPDown = { -- Set to force HP to or below shinobiRingMaxHP -- 970
         Ammo = { Name = 'Tiphia Sting', Priority = -20 },


### PR DESCRIPTION
Add commas to fix `Nin.lua:588: '}' expected (to close '{' at line 116) near 'ShinobiRingHPDown'` to Nin.lua